### PR TITLE
Add default export for some bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "default": "./src/index.js"
     },
     "./mdx": {
       "types": "./src/mdx.d.ts",
-      "import": "./src/mdx.js"
+      "import": "./src/mdx.js",
+      "default": "./src/mdx.js"
     }
   },
   "files": [


### PR DESCRIPTION
Seems some bundlers (webpack, turbopack) can't import this when the rehype package is passed as a string. 

Tracking the issue here, but adding the default key also fixes it

https://github.com/vercel/next.js/issues/73757

Would appreciate if you could merge + cut a release. 