### PR TITLE
feat: add support for mdsvex

### DIFF
--- a/mdsvex/package.json
+++ b/mdsvex/package.json
@@ -1,0 +1,6 @@
+{
+	"internal": true,
+	"main": "../src/mdsvex.js",
+	"type": "module",
+	"types": "../src/mdsvex.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -21,11 +21,17 @@
 			"types": "./src/mdx.d.ts",
 			"import": "./src/mdx.js",
 			"default": "./src/mdx.js"
+		},
+		"./mdsvex": {
+			"types": "./src/mdsvex.d.ts",
+			"import": "./src/mdsvex.js",
+			"default": "./src/mdsvex.js"
 		}
 	},
 	"files": [
 		"src",
-		"mdx"
+		"mdx",
+		"mdsvex"
 	],
 	"scripts": {
 		"format:check": "prettier . --cache --check",

--- a/readme.md
+++ b/readme.md
@@ -82,3 +82,45 @@ declare module '*.mdx' {
   export default function MDXContent(props: MDXProps): JSX.Element
 }
 ```
+
+## How to use with MDSvex
+
+When transforming [MDSvex](https://mdsvex.com/) documents, you can expose the table of contents in
+the metadata.
+
+```js
+import { compile } from "mdsvex";
+import withSlugs from "rehype-slug";
+import withToc from "@stefanprobst/rehype-extract-toc";
+import withTocExport from "@stefanprobst/rehype-extract-toc/mdsvex";
+
+async function run() {
+	const file = await compile(doc, {
+		rehypePlugins: [
+			withSlugs,
+			withToc,
+			withTocExport,
+			/** Optionally, provide a custom name for the export. */
+			// [withTocExport, { name: 'toc' }],
+		],
+	});
+
+	console.log(String(file));
+}
+
+run();
+```
+
+If you are using TypeScript, you can add typings with:
+
+```ts
+/** mdsvex.d.ts (should be referenced in `tsconfig.json#include`) */
+declare module "*.md" {
+	import type { SvelteComponent } from "svelte";
+	import type { Toc } from "@stefanprobst/rehype-extract-toc";
+
+	export default class Comp extends SvelteComponent {}
+
+	export const metadata: Record<string, unknown> & { tableOfContents: Toc };
+}
+```

--- a/src/mdsvex.d.ts
+++ b/src/mdsvex.d.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from "unified";
+
+export interface RehypeExportTocMdsvexOptions {
+	/**
+	 * The variable to export the table of contents as.
+	 *
+	 * @default 'tableOfContents'
+	 */
+	name?: string;
+}
+
+declare const mdsvex: Plugin<[RehypeExportTocMdsvexOptions?]>;
+
+export default mdsvex;
+

--- a/src/mdsvex.js
+++ b/src/mdsvex.js
@@ -1,0 +1,16 @@
+import { name as isIdentifierName } from "estree-util-is-identifier-name";
+
+export default function mdsvex({ name = "tableOfContents" } = {}) {
+	if (!isIdentifierName(name)) {
+		throw new Error(`The name should be a valid identifier name, got: ${JSON.stringify(name)}`);
+	}
+
+	return function transformer(_tree, vfile) {
+		if (vfile.data.toc) {
+			vfile.data.fm = {
+				...vfile.data.fm,
+				[name]: vfile.data.toc,
+			};
+		}
+	};
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,7 @@ import toHtml from "rehype-stringify";
 import { unified } from "unified";
 
 import withToc from "../src/index";
+import withMdsvexToc from "../src/mdsvex";
 import withTocExport from "../src/mdx";
 
 const fixtures = {
@@ -222,3 +223,50 @@ it("should throw when invalid identifier name provided as named export", async (
 		}),
 	).rejects.toThrow(/The name should be a valid identifier name, got: "##toc##"/);
 });
+
+it("should attach table of contents to vfile data frontmatter for mdsvex", async () => {
+	const processor = unified()
+		.use(fromHtml, { fragment: true })
+		.use(withSlugs)
+		.use(withToc)
+		.use(withMdsvexToc)
+		.use(toHtml);
+
+	const { data } = await processor.process(fixtures.html);
+
+	expect(data.fm).toBeDefined();
+	expect(data.fm.tableOfContents).toBeDefined();
+	expect(data.fm.tableOfContents).toEqual(data.toc);
+	expect(data.fm.tableOfContents).toMatchSnapshot();
+});
+
+it("should allow custom property name in mdsvex frontmatter", async () => {
+	const processor = unified()
+		.use(fromHtml, { fragment: true })
+		.use(withSlugs)
+		.use(withToc)
+		.use(withMdsvexToc, { name: "toc" })
+		.use(toHtml);
+
+	const { data } = await processor.process(fixtures.html);
+
+	expect(data.fm).toBeDefined();
+	expect(data.fm.toc).toBeDefined();
+	expect(data.fm.toc).toEqual(data.toc);
+});
+
+it("should throw when invalid identifier name provided as property name for mdsvex", async () => {
+	const processor = unified()
+		.use(fromHtml, { fragment: true })
+		.use(withSlugs)
+		.use(withToc)
+		.use(withMdsvexToc, { name: "##toc##" })
+		.use(toHtml);
+
+	await expect(async () => processor.process(fixtures.html)).rejects.toThrow(
+		/The name should be a valid identifier name, got: "##toc##"/,
+	);
+});
+
+
+


### PR DESCRIPTION
[MDSvex](https://mdsvex.pngwn.io) is a markdown preprocessor for [Svelte](https://svelte.dev), similar to MDX.